### PR TITLE
Parallelize tag processing

### DIFF
--- a/src/Harbor.Tagd/Program.cs
+++ b/src/Harbor.Tagd/Program.cs
@@ -2,7 +2,6 @@
 using Harbor.Tagd.API;
 using Harbor.Tagd.API.Models;
 using Harbor.Tagd.Args;
-using Harbor.Tagd.Extensions;
 using Harbor.Tagd.Notifications;
 using Harbor.Tagd.Rules;
 using Harbor.Tagd.Util;

--- a/src/Harbor.Tagd/TagSet.cs
+++ b/src/Harbor.Tagd/TagSet.cs
@@ -1,12 +1,39 @@
 ﻿using Harbor.Tagd.API.Models;
+using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 namespace Harbor.Tagd
 {
+	internal class ConcurrentTagSet : IEnumerable<Tag>
+	{
+		private readonly ConcurrentDictionary<Tag, byte> _storage = new ConcurrentDictionary<Tag, byte>();
+
+		public void Remove(Tag t) => _storage.Remove(t, out var _);
+
+		public void Add(Tag t) => _storage.TryAdd(t, 0);
+
+		public void Clear() => _storage.Clear();
+
+		public IEnumerator<Tag> GetEnumerator() => _storage.Keys.GetEnumerator();
+
+		IEnumerator IEnumerable.GetEnumerator() => _storage.Keys.GetEnumerator();
+
+		public void UnionWith(ConcurrentTagSet other)
+		{
+			foreach(var t in other)
+			{
+				_storage.TryAdd(t, 0);
+			}
+		}
+
+		public int Count => _storage.Count;
+	}
+
 	internal class TagSet
 	{
-		public HashSet<Tag> Tags { get; } = new HashSet<Tag>();
-		public HashSet<Tag> ToKeep { get; } = new HashSet<Tag>();
-		public HashSet<Tag> ToRemove { get; } = new HashSet<Tag>();
+		public ConcurrentTagSet Tags { get; } = new ConcurrentTagSet();
+		public ConcurrentTagSet ToKeep { get; } = new ConcurrentTagSet();
+		public ConcurrentTagSet ToRemove { get; } = new ConcurrentTagSet();
 	}
 }


### PR DESCRIPTION
We can make use of `Task.WhenAll(...)` to run tag processing in parallel since most of the time is spent waiting for harbor to give us data. This cuts the processing time on our instance from about two-ish minutes to around 25 seconds.

Fixes #7 