### PR TITLE
Revert "Parallelize tag processing"

### DIFF
--- a/src/Harbor.Tagd/Program.cs
+++ b/src/Harbor.Tagd/Program.cs
@@ -2,6 +2,7 @@
 using Harbor.Tagd.API;
 using Harbor.Tagd.API.Models;
 using Harbor.Tagd.Args;
+using Harbor.Tagd.Extensions;
 using Harbor.Tagd.Notifications;
 using Harbor.Tagd.Rules;
 using Harbor.Tagd.Util;

--- a/src/Harbor.Tagd/TagSet.cs
+++ b/src/Harbor.Tagd/TagSet.cs
@@ -1,39 +1,12 @@
 ﻿using Harbor.Tagd.API.Models;
-using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 namespace Harbor.Tagd
 {
-	internal class ConcurrentTagSet : IEnumerable<Tag>
-	{
-		private readonly ConcurrentDictionary<Tag, byte> _storage = new ConcurrentDictionary<Tag, byte>();
-
-		public void Remove(Tag t) => _storage.Remove(t, out var _);
-
-		public void Add(Tag t) => _storage.TryAdd(t, 0);
-
-		public void Clear() => _storage.Clear();
-
-		public IEnumerator<Tag> GetEnumerator() => _storage.Keys.GetEnumerator();
-
-		IEnumerator IEnumerable.GetEnumerator() => _storage.Keys.GetEnumerator();
-
-		public void UnionWith(ConcurrentTagSet other)
-		{
-			foreach(var t in other)
-			{
-				_storage.TryAdd(t, 0);
-			}
-		}
-
-		public int Count => _storage.Count;
-	}
-
 	internal class TagSet
 	{
-		public ConcurrentTagSet Tags { get; } = new ConcurrentTagSet();
-		public ConcurrentTagSet ToKeep { get; } = new ConcurrentTagSet();
-		public ConcurrentTagSet ToRemove { get; } = new ConcurrentTagSet();
+		public HashSet<Tag> Tags { get; } = new HashSet<Tag>();
+		public HashSet<Tag> ToKeep { get; } = new HashSet<Tag>();
+		public HashSet<Tag> ToRemove { get; } = new HashSet<Tag>();
 	}
 }


### PR DESCRIPTION
Fixes #11 by reverting HylandSoftware/Harbor.Tagd#10

Flurl clients do not handle cookies in a thread-safe way (tmenier/Flurl#318). It's not consistent which is why I didn't catch it during testing. To work around this I think we'd have to allocate a new client for each parallel call or drop Flurl from the API stack. I don't ***really*** want to re-write the API stack now that we're working on integrating this with Harbor directly so I vote we just revert this and deal with tag processing taking minutes instead of tens of seconds. For our use case it's not too bad since it's only run daily.