### PR TITLE
Update YamlDotNet version to fix security vulnerability

### DIFF
--- a/src/Harbor.Tagd/Harbor.Tagd.csproj
+++ b/src/Harbor.Tagd/Harbor.Tagd.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Steeltoe.Extensions.Configuration.ConfigServerBase" Version="2.0.0-rc1" />
-    <PackageReference Include="YamlDotNet" Version="4.2.3" />
+    <PackageReference Include="YamlDotNet" Version="5.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updated YamlDotNet Version to 5.0.0 to fix security vulnerablity.