### PR TITLE
Better handling of invalid certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,26 +47,26 @@ actually delete tags, invoke with `--destructive`.
 ### Usage
 
 ```text
-Usage: Harbor.Tagd [ -h|--help ] [ --version ] --endpoint  -u|--user U -p|--password P [ --destructive ] [ --notify-slack  ] [ -v|--verbosity V ] [ --config-file  ] [ --config-server  ] [
---config-user  ] [ --config-password  ]
+Usage: Harbor.Tagd [ -h|--help ] [ --version ] --endpoint  -u|--user U -p|--password P [ --destructive ] [ --notify-slack  ] [ -v|--verbosity V ] [ --config-file  ] [ --config-server  ] [ --config-user  ] [ --config-password  ] [ --insecure-disable-certificate-validation ]
 
  Tag Cleanup daemon for VMware Harbor Registries
 
 Required Arguments:
- --endpoint         The harbor registry to connect to
- -p, --password     The password for the user connecting to harbor
- -u, --user         The user to connect to harbor as
+ --endpoint                                 The harbor registry to connect to
+ -p, --password                             The password for the user connecting to harbor
+ -u, --user                                 The user to connect to harbor as
 
 Optional Arguments:
- --destructive      Actually delete tags instead of generating a report
- --notify-slack     Post results to this slack-compatible webhook
- --config-file      The config file to parse
- --config-server    The springboot config server to get configuration from
- --config-user      The user to login to the springboot config server as
- --config-password  The password for the springboot config server user
- -h, --help         Display this help document.
- -v, --verbosity    How verbose should logging output be
- --version          Displays the version of the current executable.
+ --destructive                              Actually delete tags instead of generating a report
+ --notify-slack                             Post results to this slack-compatible webhook
+ --config-file                              The config file to parse
+ --config-server                            The springboot config server to get configuration from
+ --config-user                              The user to login to the springboot config server as
+ --config-password                          The password for the springboot config server user
+ --insecure-disable-certificate-validation  Don't validate server certificates for Harbor
+ -h, --help                                 Display this help document.
+ -v, --verbosity                            How verbose should logging output be
+ --version                                  Displays the version of the current executable.
 ```
 
 If no value is provided for `--password` you will be prompted to enter a masked password:
@@ -120,18 +120,19 @@ $ dotnet .\dist\Harbor.Tagd.dll check --config-file rules.yml --verbosity verbos
 #### Usage
 
 ```bash
-Usage: Harbor.Tagd check [ -h|--help ] [ --version ] [ -v|--verbosity V ] [ --config-file  ] [ --config-server  ] [ --config-user  ] [ --config-password  ]
+Usage: Harbor.Tagd [ -h|--help ] [ --version ] [ -v|--verbosity V ] [ --config-file  ] [ --config-server  ] [ --config-user  ] [ --config-password  ] [ --insecure-disable-certificate-validation ]
 
  Load and validate rules
 
 Optional Arguments:
- --config-file      The config file to parse
- --config-server    The springboot config server to get configuration from
- --config-user      The user to login to the springboot config server as
- --config-password  The password for the springboot config server user
- -h, --help         Display this help document.
- -v, --verbosity    How verbose should logging output be
- --version          Displays the version of the current executable.
+ --config-file                              The config file to parse
+ --config-server                            The springboot config server to get configuration from
+ --config-user                              The user to login to the springboot config server as
+ --config-password                          The password for the springboot config server user
+ --insecure-disable-certificate-validation  Don't validate server certificates for Harbor
+ -h, --help                                 Display this help document.
+ -v, --verbosity                            How verbose should logging output be
+ --version                                  Displays the version of the current executable.
 ```
 
 ## License

--- a/src/Harbor.Tagd/Args/CommonArgs.cs
+++ b/src/Harbor.Tagd/Args/CommonArgs.cs
@@ -23,5 +23,8 @@ namespace Harbor.Tagd.Args
 
 		[NamedArgument("config-password", Description = "The password for the springboot config server user")]
 		public string ConfigPassword { get; set; }
+
+		[NamedArgument("insecure-disable-certificate-validation", Description = "Don't validate server certificates for Harbor", Action = ParseAction.StoreTrue)]
+		public bool DisableCertificateValidation { get; set; }
 	}
 }

--- a/src/Harbor.Tagd/Program.cs
+++ b/src/Harbor.Tagd/Program.cs
@@ -2,7 +2,6 @@
 using Harbor.Tagd.API;
 using Harbor.Tagd.API.Models;
 using Harbor.Tagd.Args;
-using Harbor.Tagd.Extensions;
 using Harbor.Tagd.Notifications;
 using Harbor.Tagd.Rules;
 using Harbor.Tagd.Util;
@@ -15,6 +14,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using Flurl.Http;
 
 [assembly: InternalsVisibleTo("Harbor.Tagd.Tests")]
 
@@ -79,6 +79,12 @@ namespace Harbor.Tagd
 						},
 						new SerilogLoggerFactory()
 					) : (IRuleProvider) new FilesystemRuleProvider(settings.ConfigFile);
+
+				if (settings.DisableCertificateValidation)
+				{
+					Log.Warning("Ignoring Certificate Errors");
+					FlurlHttp.Configure(f => f.HttpClientFactory = new InsecureHttpClientFactory());
+				}
 
 				if (check)
 				{

--- a/src/Harbor.Tagd/TagEngine.cs
+++ b/src/Harbor.Tagd/TagEngine.cs
@@ -100,8 +100,11 @@ namespace Harbor.Tagd
 			}
 			finally
 			{
-				Log.Information("Logging out");
-				await _harbor.Logout();
+				if (!string.IsNullOrEmpty(_harbor.SessionToken))
+				{
+					Log.Information("Logging out");
+					await _harbor.Logout();
+				}
 			}
 		}
 

--- a/src/Harbor.Tagd/Util/InsecureHttpClientFactory.cs
+++ b/src/Harbor.Tagd/Util/InsecureHttpClientFactory.cs
@@ -1,0 +1,25 @@
+﻿using System.Net.Http;
+using Flurl.Http.Configuration;
+using Serilog;
+
+namespace Harbor.Tagd.Util
+{
+	internal class InsecureHttpClientFactory : DefaultHttpClientFactory
+	{
+		public override HttpMessageHandler CreateMessageHandler()
+		{
+			var result = base.CreateMessageHandler();
+
+			if (result is HttpClientHandler http)
+			{
+				http.ServerCertificateCustomValidationCallback = (_, __, ___, ____) => true;
+			}
+			else
+			{
+				Log.Error("Unknown Message Handler Type {type}", result.GetType().FullName);
+			}
+
+			return result;
+		}
+	}
+}


### PR DESCRIPTION
We no longer try to log out if we're not logged in. If the endpoint is using an invalid certificate, that error is now surfaced to the user instead of telling them they're not logged in. I also added an option to disable certificate validation.

Fixes #9 