### PR TITLE
Add support for Harbor 1.7.0+

### DIFF
--- a/src/Harbor.Tagd/API/Models/SystemInfo.cs
+++ b/src/Harbor.Tagd/API/Models/SystemInfo.cs
@@ -1,0 +1,10 @@
+using Newtonsoft.Json;
+
+namespace Harbor.Tagd.API.Models
+{
+    public class SystemInfo
+    {
+        [JsonProperty("harbor_version")]
+        public string Version { get; set; }
+    }
+}

--- a/src/Harbor.Tagd/Harbor.Tagd.csproj
+++ b/src/Harbor.Tagd/Harbor.Tagd.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="SemanticVersioning" Version="1.2.0" />
     <PackageReference Include="Serilog" Version="2.6.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />


### PR DESCRIPTION
Starting in 1.7.0 the login route moved to `/c/login` (see goharbor/harbor#5932).

Tagd now checks the version of harbor and will use the right cookie and login endpoint depending on the version returned by `/api/systeminfo`.

Fixes #16 