### PR TITLE
Update the README to point to official tag retention docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 [![Build Status](https://travis-ci.org/HylandSoftware/Harbor.Tagd.svg?branch=master)](https://travis-ci.org/HylandSoftware/Harbor.Tagd) [![Coverage Status](https://coveralls.io/repos/github/HylandSoftware/Harbor.Tagd/badge.svg?branch=master)](https://coveralls.io/github/HylandSoftware/Harbor.Tagd?branch=master)
 
+> **NOTE** Much of the functionality of `tagd` is now available natively in
+> Harbor 1.9. Please consider migrating your retention policies to Harbor
+> instead of using `tagd`. See the [Harbor Documentation](https://github.com/goharbor/harbor/blob/master/docs/user_guide.md#tag-retention-rules)
+> for more details.
+
 `tagd` automates the process of cleaning up old tags from your Harbor container
 registries. You can override the default policy to be more or less specific for
 projects and repositories if needed.


### PR DESCRIPTION
Harbor 1.9 is now generally available and includes much of the functionality that `tagd` provides. This updates the README to point people to the native solution first.